### PR TITLE
Implementación de paginación para listar publicaciones en lotes de 10

### DIFF
--- a/src/main/java/com/infsis/socialpagebackend/posts/controllers/PostController.java
+++ b/src/main/java/com/infsis/socialpagebackend/posts/controllers/PostController.java
@@ -83,4 +83,14 @@ public class PostController {
         return ResponseEntity.ok(posts);
     }
 
+    @GetMapping("/paged")
+public ResponseEntity<List<PostDTO>> getPagedPosts(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+) {
+    List<PostDTO> posts = postService.getPagedPosts(page, size);
+    return ResponseEntity.ok(posts);
+}
+
+
 }

--- a/src/main/java/com/infsis/socialpagebackend/posts/repositories/PostRepository.java
+++ b/src/main/java/com/infsis/socialpagebackend/posts/repositories/PostRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Integer> {
@@ -17,4 +19,7 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 
     @Query("SELECT p FROM Post p WHERE p.uuid = ?1")
     Post findOneByUuid(String Uuid);
+    @Query("SELECT p FROM Post p WHERE p.deleted = false ORDER BY p.createdDate DESC")
+    Page<Post> findAllPaged(Pageable pageable);
+
 }

--- a/src/main/java/com/infsis/socialpagebackend/posts/services/PostService.java
+++ b/src/main/java/com/infsis/socialpagebackend/posts/services/PostService.java
@@ -20,10 +20,14 @@ import com.infsis.socialpagebackend.reactions.repositories.EmojiTypeRepository;
 import com.infsis.socialpagebackend.reactions.repositories.PostReactionRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -413,4 +417,18 @@ public class PostService {
         }
         return mediaItems;
     }
+
+
+
+    public List<PostDTO> getPagedPosts(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdDate").descending());
+        Page<Post> posts = postRepository.findAllPaged(pageable);
+    
+        return posts.stream()
+                    .map(post -> postMapper.toDTO(post, getPostReactionCounterDTO(post), getCommentCounter(post.getUuid())))
+                    .collect(Collectors.toList());
+    }
+    
+
+    
 }


### PR DESCRIPTION
Implementación de paginación en lotes de 10 para listar publicaciones.
- Se agregó la funcionalidad de paginación en PostService.
- Se creó el endpoint GET /posts/paged para obtener publicaciones en lotes.
- Se probó exitosamente con Postman.